### PR TITLE
Rest API Authentication

### DIFF
--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -54,6 +54,8 @@ def _req(method, url, quiet=False, auth=None, **kwargs):
     if r.status_code in (200, 201):
         if not quiet:
             app_logger.debug(report)
+    elif r.status_code == 401:
+        raise RestCommunicationError('Invalid auth credentials')
     else:
         app_logger.error(report)
     return r

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -1,9 +1,10 @@
 import requests
 from urllib.parse import urljoin
-from egcg_core.config import default as cfg
+from egcg_core.config import default
 from egcg_core.app_logging import logging_default as log_cfg
 from egcg_core.exceptions import RestCommunicationError
 
+cfg = default['rest_api']
 app_logger = log_cfg.get_logger(__name__)
 
 table = {' ': '', '\'': '"', 'None': 'null'}
@@ -17,7 +18,7 @@ def _translate(s):
 
 def api_url(endpoint, **query_args):
     url = '{base_url}/{endpoint}/'.format(
-        base_url=cfg.query('rest_api', 'url').rstrip('/'), endpoint=endpoint
+        base_url=cfg['url'].rstrip('/'), endpoint=endpoint
     )
     if query_args:
         query = '?' + '&'.join(['%s=%s' % (k, v) for k, v in query_args.items()])
@@ -37,8 +38,15 @@ def _parse_query_string(query_string, requires=None):
     return query
 
 
-def _req(method, url, quiet=False, **kwargs):
-    r = requests.request(method, url, **kwargs)
+def _req(method, url, quiet=False, auth=None, **kwargs):
+
+    default_auth = None
+    if 'username' in cfg and 'password' in cfg:
+        default_auth = (cfg['username'], cfg['password'])
+
+    if auth is None:
+        auth = default_auth
+    r = requests.request(method, url, auth=auth, **kwargs)
     # e.g: 'POST <url> ({"some": "args"}) -> {"some": "content"}. Status code 201. Reason: CREATED
     report = '%s %s (%s) -> %s. Status code %s. Reason: %s' % (
         r.request.method, r.request.path_url, kwargs, r.content.decode('utf-8'), r.status_code, r.reason
@@ -51,52 +59,51 @@ def _req(method, url, quiet=False, **kwargs):
     return r
 
 
-def get_content(endpoint, paginate=True, quiet=False, **query_args):
+def get_content(endpoint, paginate=True, quiet=False, auth=None, **query_args):
     if paginate:
         query_args.update(
             max_results=query_args.pop('max_results', 100),  # default to page size of 100
             page=query_args.pop('page', 1)
         )
     url = api_url(endpoint, **query_args)
+    return _req('GET', url, quiet=quiet, auth=auth).json()
 
-    return _req('GET', url, quiet=quiet).json()
 
-
-def get_documents(endpoint, paginate=True, all_pages=False, quiet=False, **query_args):
-    content = get_content(endpoint, paginate, quiet, **query_args)
+def get_documents(endpoint, paginate=True, all_pages=False, quiet=False, auth=None, **query_args):
+    content = get_content(endpoint, paginate, quiet, auth, **query_args)
     elements = content['data']
 
     if all_pages and 'next' in content['_links']:
         next_query = _parse_query_string(content['_links']['next']['href'], requires=('max_results', 'page'))
         query_args.update(next_query)
-        elements.extend(get_documents(endpoint, all_pages=True, quiet=quiet, **query_args))
+        elements.extend(get_documents(endpoint, all_pages=True, quiet=quiet, auth=auth, **query_args))
 
     return elements
 
 
-def get_document(endpoint, idx=0, **query_args):
-    documents = get_documents(endpoint, **query_args)
+def get_document(endpoint, idx=0, auth=None, **query_args):
+    documents = get_documents(endpoint, auth=auth, **query_args)
     if documents:
         return documents[idx]
     else:
         app_logger.warning('No document found in endpoint %s for %s', endpoint, query_args)
 
 
-def post_entry(endpoint, payload):
-    r = _req('POST', api_url(endpoint), json=payload)
+def post_entry(endpoint, payload, auth=None):
+    r = _req('POST', api_url(endpoint), auth=auth, json=payload)
     if r.status_code != 200:
         return False
     return True
 
 
-def put_entry(endpoint, element_id, payload):
-    r = _req('PUT', urljoin(api_url(endpoint), element_id), json=payload)
+def put_entry(endpoint, element_id, payload, auth=None):
+    r = _req('PUT', urljoin(api_url(endpoint), element_id), auth=auth, json=payload)
     if r.status_code != 200:
         return False
     return True
 
 
-def _patch_entry(endpoint, doc, payload, update_lists=None):
+def _patch_entry(endpoint, doc, payload, auth=None, update_lists=None):
     """
     Patch a specific database item (specified by doc) with the given data payload.
     :param str endpoint:
@@ -112,13 +119,13 @@ def _patch_entry(endpoint, doc, payload, update_lists=None):
             content = doc.get(l, [])
             new_content = [x for x in _payload.get(l, []) if x not in content]
             _payload[l] = content + new_content
-    r = _req('PATCH', url, headers=headers, json=_payload)
+    r = _req('PATCH', url, auth=auth, headers=headers, json=_payload)
     if r.status_code == 200:
         return True
     return False
 
 
-def patch_entry(endpoint, payload, id_field, element_id, update_lists=None):
+def patch_entry(endpoint, payload, id_field, element_id, auth=None, update_lists=None):
     """
     Retrieve a document at the given endpoint with the given unique ID, and patch it with some data.
     :param str endpoint:
@@ -129,11 +136,11 @@ def patch_entry(endpoint, payload, id_field, element_id, update_lists=None):
     """
     doc = get_document(endpoint, where={id_field: element_id})
     if doc:
-        return _patch_entry(endpoint, doc, payload, update_lists)
+        return _patch_entry(endpoint, doc, payload, auth, update_lists)
     return False
 
 
-def patch_entries(endpoint, payload, update_lists=None, **query_args):
+def patch_entries(endpoint, payload, update_lists=None, auth=None, **query_args):
     """
     Retrieve many documents and patch them all with the same data.
     :param str endpoint:
@@ -146,7 +153,7 @@ def patch_entries(endpoint, payload, update_lists=None, **query_args):
         success = True
         nb_docs = 0
         for doc in docs:
-            if _patch_entry(endpoint, doc, payload, update_lists):
+            if _patch_entry(endpoint, doc, payload, auth, update_lists):
                 nb_docs += 1
             else:
                 success = False
@@ -155,7 +162,7 @@ def patch_entries(endpoint, payload, update_lists=None, **query_args):
     return False
 
 
-def post_or_patch(endpoint, input_json, id_field=None, update_lists=None):
+def post_or_patch(endpoint, input_json, auth=None, id_field=None, update_lists=None):
     """
     For each document supplied, either post to the endpoint if the unique id doesn't yet exist there, or
     patch if it does.
@@ -170,8 +177,8 @@ def post_or_patch(endpoint, input_json, id_field=None, update_lists=None):
         doc = get_document(endpoint, where={id_field: _payload[id_field]})
         if doc:
             _payload.pop(id_field)
-            s = _patch_entry(endpoint, doc, _payload, update_lists)
+            s = _patch_entry(endpoint, doc, _payload, auth, update_lists)
         else:
-            s = post_entry(endpoint, _payload)
+            s = post_entry(endpoint, _payload, auth)
         success = success and s
     return success

--- a/etc/example_egcg.yaml
+++ b/etc/example_egcg.yaml
@@ -4,6 +4,8 @@ default:
 
     rest_api:
         url: 'http://localhost:4999/api/0.1'
+        username: 'a_user'
+        password: 'a_password'
 
     ncbi_cache: ':memory:'
 

--- a/tests/test_rest_communication.py
+++ b/tests/test_rest_communication.py
@@ -139,7 +139,7 @@ test_patch_document = {
 
 @patch('egcg_core.rest_communication.get_document', return_value=test_patch_document)
 @patched_response
-def test_patch_entry(mocked_request, mocked_get_doc):
+def test_patch_entry(mocked_response, mocked_get_doc):
     patching_payload = {'list_to_update': ['another']}
     rest_communication.patch_entry(
         test_endpoint,
@@ -150,7 +150,7 @@ def test_patch_entry(mocked_request, mocked_get_doc):
     )
 
     mocked_get_doc.assert_called_with(test_endpoint, where={'uid': 'a_unique_id'})
-    mocked_request.assert_called_with(
+    mocked_response.assert_called_with(
         'PATCH',
         rest_url(test_endpoint) + '1337',
         headers={'If-Match': 1234567},
@@ -184,7 +184,6 @@ def test_post_or_patch():
             'an_endpoint',
             test_post_or_patch_doc,
             test_post_or_patch_payload_no_uid,
-            None,
             ['list_to_update']
         )
         assert success is True
@@ -194,5 +193,5 @@ def test_post_or_patch():
             'an_endpoint', [test_post_or_patch_payload], id_field='uid', update_lists=['list_to_update']
         )
         mget.assert_called_with('an_endpoint', where={'uid': '1337'})
-        mpost.assert_called_with('an_endpoint', test_post_or_patch_payload, None)
+        mpost.assert_called_with('an_endpoint', test_post_or_patch_payload)
         assert success is True

--- a/tests/test_rest_communication.py
+++ b/tests/test_rest_communication.py
@@ -123,13 +123,13 @@ def test_get_document():
 @patched_response
 def test_post_entry(mocked_response):
     rest_communication.post_entry(test_endpoint, payload=test_request_content)
-    mocked_response.assert_called_with('POST', rest_url(test_endpoint), auth=None, json=test_request_content)
+    mocked_response.assert_called_with('POST', rest_url(test_endpoint), auth=auth, json=test_request_content)
 
 
 @patched_response
 def test_put_entry(mocked_response):
     rest_communication.put_entry(test_endpoint, 'an_element_id', payload=test_request_content)
-    mocked_response.assert_called_with('PUT', rest_url(test_endpoint) + 'an_element_id', auth=None, json=test_request_content)
+    mocked_response.assert_called_with('PUT', rest_url(test_endpoint) + 'an_element_id', auth=auth, json=test_request_content)
 
 
 test_patch_document = {
@@ -154,7 +154,7 @@ def test_patch_entry(mocked_request, mocked_get_doc):
         'PATCH',
         rest_url(test_endpoint) + '1337',
         headers={'If-Match': 1234567},
-        auth=None,
+        auth=auth,
         json={'list_to_update': ['this', 'that', 'other', 'another']}
     )
 


### PR DESCRIPTION
This adds authentication headers to requests made in `rest_communication`, depending on configs. Intended for use with an upcoming authenticated version of EdinburghGenomics/Reporting-App, but is backward-compatible. Closes #3.
