### PR TITLE
Config reloading

### DIFF
--- a/tests/test_clarity.py
+++ b/tests/test_clarity.py
@@ -34,6 +34,8 @@ class FakeContainer:
 
 
 class FakeProcess:
+    date_run = 'a_date_run'
+
     @staticmethod
     def all_inputs():
         return [Mock(samples=[FakeEntity('this'), FakeEntity('that')])]
@@ -238,3 +240,11 @@ def test_get_samples_sequenced_with(mocked_get_sample, mocked_containers, mocked
 def test_get_released_samples(mocked_lims):
     assert clarity.get_released_samples() == ['that', 'this']
     mocked_lims.assert_called_with(type='Data Release EG 1.0')
+
+
+@patched_clarity('get_sample', Mock(artifact=Mock(id='an_artifact_id')))
+@patched_lims('get_processes', [FakeProcess])
+def test_get_sample_release_date(mocked_get_procs, mocked_get_sample):
+    assert clarity.get_sample_release_date('a_sample_name') == 'a_date_run'
+    mocked_get_procs.assert_called_with(type='Data Release EG 1.0', inputartifactlimsid='an_artifact_id')
+    mocked_get_sample.assert_called_with('a_sample_name')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,45 +1,50 @@
-import os
-import pytest
+from os.path import join
 from tests import TestEGCG
-from egcg_core.config import EnvConfiguration
-from egcg_core.exceptions import EGCGError
+from egcg_core.config import Configuration, EnvConfiguration
 
 
 class TestConfiguration(TestEGCG):
     def setUp(self):
-        self.cfg = EnvConfiguration(
-            (
-                os.getenv('EGCGCONFIG'),
-                os.path.join(self.assets_path, '..', '..', 'etc', 'example_egcg.yaml')
-            )
-        )
-
-    def test_get(self):
-        get = self.cfg.get
-        assert get('nonexistent_thing') is None
-        assert get('nonexistent_thing', 'a_default') == 'a_default'
-        assert self.cfg.get('executor').get('job_execution') == 'local'
+        self.cfg = Configuration(self.etc_config)
 
     def test_find_config_file(self):
-        existing_cfg_file = os.path.join(self.assets_path, '..', '..', 'etc', 'example_egcg.yaml')
-        non_existing_cfg_file = os.path.join(self.assets_path, 'a_file_that_does_not_exist.txt')
+        existing_cfg_file = self.etc_config
+        non_existing_cfg_file = join(self.etc, 'non_existent.yaml')
         assert self.cfg._find_config_file((non_existing_cfg_file, existing_cfg_file)) == existing_cfg_file
 
         self.cfg.content = None
         self.cfg._find_config_file((non_existing_cfg_file,))
         assert self.cfg.content is None
 
+    def test_load_config_file(self):
+        original_content = self.cfg.content
+        self.cfg.content = None
+        self.cfg.load_config_file(self.etc_config)
+        assert self.cfg.content == original_content
+
+    def test_get(self):
+        assert self.cfg.get('nonexistent_thing') is None
+        assert self.cfg.get('nonexistent_thing', 'a_default') == 'a_default'
+        assert self.cfg.get('default').get('executor').get('job_execution') == 'local'
+
     def test_query(self):
-        assert self.cfg.query('executor', 'job_execution') == 'local'
-        assert self.cfg.query('nonexistent_thing') is None
+        assert self.cfg.query('default', 'executor', 'job_execution') == 'local'
+        assert self.cfg.query('default', 'nonexistent_thing') is None
+
+    def test_contains(self):
+        assert 'default' in self.cfg
+
+
+class TestEnvConfiguration(TestConfiguration):
+    def setUp(self):
+        self.cfg = EnvConfiguration(self.etc_config)
+
+    def test_get(self):
+        assert self.cfg.get('executor').get('job_execution') == 'local'
+
+    def test_query(self):
         assert self.cfg.query('logging', 'handlers', 'nonexistent_handler') is None
-        assert self.cfg.query('logging') == {
-            'stream_handlers': [{'stream': 'ext://sys.stdout', 'level': 'DEBUG'}],
-            'file_handlers': [{'filename': 'tests/assets/test.log', 'mode': 'a', 'level': 'WARNING'}],
-            'timed_rotating_file_handlers': [{'filename': 'tests/assets/test.log', 'when': 'h', 'interval': 1}],
-            'datefmt': '%Y-%b-%d %H:%M:%S',
-            'format': '[%(asctime)s][%(name)s][%(levelname)s] %(message)s'
-        }
+        assert self.cfg.query('logging', 'datefmt') == '%Y-%b-%d %H:%M:%S'
 
     def test_merge_dicts(self):
         default_dict = {
@@ -88,3 +93,6 @@ class TestConfiguration(TestEGCG):
         }
 
         assert dict(self.cfg._merge_dicts(default_dict, default_dict)) == default_dict
+
+    def test_contains(self):
+        assert 'rest_api' in self.cfg

--- a/tests/test_rest_communication.py
+++ b/tests/test_rest_communication.py
@@ -1,9 +1,11 @@
 import json
 import pytest
 from unittest.mock import patch
-from tests import FakeRestResponse
+from tests import FakeRestResponse, TestEGCG
 from egcg_core import rest_communication
 from egcg_core.exceptions import RestCommunicationError
+from egcg_core.config import cfg
+cfg.load_config_file(TestEGCG.etc_config)
 
 
 def rest_url(endpoint):


### PR DESCRIPTION
Config objects are now able to optionally use a search path rather than one file path in `load_config`. This allows the egcg_core config to either load the client config's file or discover it independently through the client config's search path.

Tests for script writers and clarity have also been updated.
