### PR TITLE
Notifications

### DIFF
--- a/egcg_core/notifications/__init__.py
+++ b/egcg_core/notifications/__init__.py
@@ -1,0 +1,22 @@
+from egcg_core.app_logging import AppLogger
+from egcg_core.config import cfg
+from .asana_notification import AsanaNotification
+from .email_notification import EmailNotification
+from .log_notification import LogNotification
+
+
+class NotificationCentre(AppLogger):
+    def __init__(self, name):
+        self.name = name
+        self.subscribers = []
+
+    def setup_subscribers(self, *subscribers):
+        for s in subscribers:
+            if cfg.query('notifications', s.config_domain):
+                self.subscribers.append(s)
+            else:
+                self.warning('No config found for ' + s.__class__.__name__)
+
+    def notify(self, msg):
+        for s in self.subscribers:
+            s.notify(msg)

--- a/egcg_core/notifications/asana_notification.py
+++ b/egcg_core/notifications/asana_notification.py
@@ -21,7 +21,7 @@ class AsanaNotification(Notification):
     @property
     def task(self):
         if self._task is None:
-            tasks = list(self.client.tasks.find_all(project=self.project_id, completed=False))
+            tasks = list(self.client.tasks.find_all(project=self.project_id))
             task_ent = self._get_entity(tasks, self.task_id)
             if task_ent is None:
                 task_ent = self._create_task()

--- a/egcg_core/notifications/asana_notification.py
+++ b/egcg_core/notifications/asana_notification.py
@@ -12,11 +12,10 @@ class AsanaNotification(Notification):
         self.workspace_id = self.config['workspace_id']
         self.project_id = self.config['project_id']
         self._task = None
-        self.task_template = {
-            'name': task_id,
-            'notes': self.config.get('task_description'),
-            'projects': [self.project_id]
-        }
+        self.task_template = {'name': task_id, 'projects': [self.project_id]}
+        task_description = self.config.get('task_description')
+        if task_description:
+            self.task_template['notes'] = self.config.get('task_description')
 
     def notify(self, msg):
         self.client.tasks.add_comment(self.task['id'], text=msg)

--- a/egcg_core/notifications/asana_notification.py
+++ b/egcg_core/notifications/asana_notification.py
@@ -1,0 +1,42 @@
+import asana
+from .notification import Notification
+
+
+class AsanaNotification(Notification):
+    config_domain = 'asana'
+
+    def __init__(self, task_id):
+        super().__init__(task_id)
+        self.task_id = self.name
+        self.client = asana.Client.access_token(self.config['access_token'])
+        self.workspace_id = self.config['workspace_id']
+        self.project_id = self.config['project_id']
+        self._task = None
+        self.task_template = {
+            'name': task_id,
+            'notes': self.config.get('task_description'),
+            'projects': [self.project_id]
+        }
+
+    def notify(self, msg):
+        self.client.tasks.add_comment(self.task['id'], text=msg)
+        self.client.tasks.update(self.task['id'], completed=False)
+
+    @property
+    def task(self):
+        if self._task is None:
+            tasks = list(self.client.tasks.find_all(project=self.project_id, completed=False))
+            task_ent = self._get_entity(tasks, self.task_id)
+            if task_ent is None:
+                task_ent = self._create_task()
+            self._task = self.client.tasks.find_by_id(task_ent['id'])
+        return self._task
+
+    @staticmethod
+    def _get_entity(collection, name):
+        for e in collection:
+            if e['name'] == name:
+                return e
+
+    def _create_task(self):
+        return self.client.tasks.create_in_workspace(self.workspace_id, self.task_template)

--- a/egcg_core/notifications/asana_notification.py
+++ b/egcg_core/notifications/asana_notification.py
@@ -3,21 +3,18 @@ from .notification import Notification
 
 
 class AsanaNotification(Notification):
-    config_domain = 'asana'
-
-    def __init__(self, task_id):
-        super().__init__(task_id)
+    def __init__(self, name, workspace_id, project_id, access_token, task_description=None):
+        super().__init__(name)
         self.task_id = self.name
-        self.client = asana.Client.access_token(self.config['access_token'])
-        self.workspace_id = self.config['workspace_id']
-        self.project_id = self.config['project_id']
+        self.workspace_id = workspace_id
+        self.project_id = project_id
+        self.client = asana.Client.access_token(access_token)
         self._task = None
-        self.task_template = {'name': task_id, 'projects': [self.project_id]}
-        task_description = self.config.get('task_description')
+        self.task_template = {'name': name, 'projects': [self.project_id]}
         if task_description:
-            self.task_template['notes'] = self.config.get('task_description')
+            self.task_template['notes'] = task_description
 
-    def notify(self, msg):
+    def _notify(self, msg):
         self.client.tasks.add_comment(self.task['id'], text=msg)
         self.client.tasks.update(self.task['id'], completed=False)
 

--- a/egcg_core/notifications/email_notification.py
+++ b/egcg_core/notifications/email_notification.py
@@ -1,0 +1,81 @@
+from os.path import join, dirname, abspath
+import jinja2
+import smtplib
+from time import sleep
+from email.mime.text import MIMEText
+from egcg_core.exceptions import EGCGError
+from .notification import Notification
+
+
+class EmailNotification(Notification):
+    config_domain = 'email'
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.reporter = self.config['sender']
+        self.recipients = self.config['recipients']
+        self.mailhost = self.config['mailhost']
+        self.strict = self.config.get('strict', False)
+        self.port = self.config['port']
+        self.email_template = self.config.get(
+            'email_template',
+            join(dirname(abspath(__file__)), '..', '..', 'etc', 'email_notification.html')
+        )
+
+    def notify(self, body):
+        msg = self._prepare_message(body)
+        mail_success = self._try_send(msg)
+        if not mail_success:
+            if self.strict is True:
+                raise EGCGError('Failed to send message: ' + body)
+            else:
+                self.critical('Failed to send message: ' + body)
+
+    def _try_send(self, msg, retries=3):
+        """
+        Prepare a MIMEText message from body and diagnostics, and try to send a set number of times.
+        :param int retries: Which retry we're currently on
+        :return: True if a message is sucessfully sent, otherwise False
+        """
+        try:
+            self._connect_and_send(msg)
+            return True
+        except (smtplib.SMTPException, TimeoutError) as e:
+            retries -= 1
+            self.warning('Encountered a %s exception. %s retries remaining', str(e), retries)
+            if retries:
+                sleep(2)
+                return self._try_send(msg, retries)
+            else:
+                return False
+
+    def _prepare_message(self, body):
+        """
+        Use Jinja to build a MIMEText html-formatted email.
+        :param str body: The main body of the email to send
+        """
+        content = jinja2.Template(open(self.email_template).read())
+        msg = MIMEText(
+            content.render(title=self.name, body=self._prepare_string(body, {' ': '&nbsp', '\n': '<br/>'})),
+            'html'
+        )
+
+        msg['Subject'] = self.name
+        msg['From'] = self.reporter
+        msg['To'] = ','.join(self.recipients)
+        return msg
+
+    @staticmethod
+    def _prepare_string(in_string, charmap):
+        for k in charmap:
+            in_string = in_string.replace(k, charmap[k])
+        return in_string
+
+    def _connect_and_send(self, msg):
+        connection = smtplib.SMTP(self.mailhost, self.port)
+        connection.send_message(
+            msg,
+            self.reporter,
+            self.recipients
+        )
+        connection.quit()

--- a/egcg_core/notifications/email_notification.py
+++ b/egcg_core/notifications/email_notification.py
@@ -8,21 +8,18 @@ from .notification import Notification
 
 
 class EmailNotification(Notification):
-    config_domain = 'email'
-
-    def __init__(self, name):
+    def __init__(self, name, mailhost, port, sender, recipients, strict=False, email_template=None):
         super().__init__(name)
-        self.reporter = self.config['sender']
-        self.recipients = self.config['recipients']
-        self.mailhost = self.config['mailhost']
-        self.strict = self.config.get('strict', False)
-        self.port = self.config['port']
-        self.email_template = self.config.get(
-            'email_template',
-            join(dirname(abspath(__file__)), '..', '..', 'etc', 'email_notification.html')
-        )
+        self.mailhost = mailhost
+        self.port = port
+        self.sender = sender
+        self.recipients = recipients
+        self.strict = strict
+        self.email_template = email_template
+        if email_template is None:
+            self.email_template = join(dirname(abspath(__file__)), '..', '..', 'etc', 'email_notification.html')
 
-    def notify(self, body):
+    def _notify(self, body):
         msg = self._prepare_message(body)
         mail_success = self._try_send(msg)
         if not mail_success:
@@ -61,7 +58,7 @@ class EmailNotification(Notification):
         )
 
         msg['Subject'] = self.name
-        msg['From'] = self.reporter
+        msg['From'] = self.sender
         msg['To'] = ','.join(self.recipients)
         return msg
 
@@ -75,7 +72,7 @@ class EmailNotification(Notification):
         connection = smtplib.SMTP(self.mailhost, self.port)
         connection.send_message(
             msg,
-            self.reporter,
+            self.sender,
             self.recipients
         )
         connection.quit()

--- a/egcg_core/notifications/log_notification.py
+++ b/egcg_core/notifications/log_notification.py
@@ -3,13 +3,11 @@ from .notification import Notification
 
 
 class LogNotification(Notification):
-    """Logs via log_cfg, and also to a notification file with the format'[date time][dataset_name] msg'"""
+    """Logs via log_cfg, and also to a notification file with the format'[date time][self.name] msg'"""
 
-    config_domain = 'log'
-
-    def __init__(self, name):
+    def __init__(self, name, log_file):
         super().__init__(name)
-        handler = logging.FileHandler(filename=self.config['log_file'], mode='a')
+        handler = logging.FileHandler(filename=log_file, mode='a')
         handler.setFormatter(
             logging.Formatter(
                 fmt='[%(asctime)s][' + self.name + '] %(message)s',
@@ -19,5 +17,5 @@ class LogNotification(Notification):
         handler.setLevel(logging.INFO)
         self._logger.addHandler(handler)
 
-    def notify(self, msg):
+    def _notify(self, msg):
         self.info(msg)

--- a/egcg_core/notifications/log_notification.py
+++ b/egcg_core/notifications/log_notification.py
@@ -1,0 +1,23 @@
+import logging
+from .notification import Notification
+
+
+class LogNotification(Notification):
+    """Logs via log_cfg, and also to a notification file with the format'[date time][dataset_name] msg'"""
+
+    config_domain = 'log'
+
+    def __init__(self, name):
+        super().__init__(name)
+        handler = logging.FileHandler(filename=self.config['log_file'], mode='a')
+        handler.setFormatter(
+            logging.Formatter(
+                fmt='[%(asctime)s][' + self.name + '] %(message)s',
+                datefmt='%Y-%b-%d %H:%M:%S'
+            )
+        )
+        handler.setLevel(logging.INFO)
+        self._logger.addHandler(handler)
+
+    def notify(self, msg):
+        self.info(msg)

--- a/egcg_core/notifications/notification.py
+++ b/egcg_core/notifications/notification.py
@@ -1,0 +1,13 @@
+from egcg_core.config import cfg
+from egcg_core.app_logging import AppLogger
+
+
+class Notification(AppLogger):
+    config_domain = 'generic'
+
+    def __init__(self, name):
+        self.name = name
+        self.config = cfg['notifications'][self.config_domain]
+
+    def notify(self, msg):
+        raise NotImplementedError

--- a/egcg_core/notifications/notification.py
+++ b/egcg_core/notifications/notification.py
@@ -1,13 +1,20 @@
-from egcg_core.config import cfg
 from egcg_core.app_logging import AppLogger
 
 
 class Notification(AppLogger):
-    config_domain = 'generic'
+    preprocess = None
 
-    def __init__(self, name):
+    def __init__(self, name, **kwargs):
         self.name = name
-        self.config = cfg['notifications'][self.config_domain]
+
+    def _notify(self, msg):
+        raise NotImplementedError
 
     def notify(self, msg):
-        raise NotImplementedError
+        if self.preprocess:
+            msg = self.preprocess(msg)
+        return self._notify(msg)
+
+    @staticmethod
+    def preprocess_message(msg):
+        return msg

--- a/egcg_core/validate_config.py
+++ b/egcg_core/validate_config.py
@@ -1,6 +1,5 @@
 import re
 import sys
-from os import environ
 from os.path import abspath, dirname, basename
 
 table = str.maketrans('', '', '\'" []')
@@ -85,11 +84,14 @@ def validate_main_config(cfg, file):
 
 
 def main():
-    environ['EGCGCONFIG'] = sys.argv[1]
-
     sys.path.append(dirname(dirname(abspath(__file__))))
-    from egcg_core import config
-    validate_main_config(config.default, sys.argv[2])
+    from egcg_core.config import cfg
+
+    config_file = sys.argv[1]
+    source_code = sys.argv[2]
+
+    cfg.load_config_file(config_file)
+    validate_main_config(cfg, source_code)
 
 
 if __name__ == '__main__':

--- a/etc/email_notification.html
+++ b/etc/email_notification.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        table, th, td {
+            border: 1px solid black;
+            border-collapse: collapse;
+        }
+    </style>
+</head>
+<body>
+    <h2>{{ title }}</h2>
+    <p>{{ body }}</p>
+</body>
+</html>

--- a/etc/example_egcg.yaml
+++ b/etc/example_egcg.yaml
@@ -37,8 +37,8 @@ default:
 
     notifications:
         email:
-            sender: 'a_sender'
-            recipients: ['this', 'that', 'other']
+            sender: 'this'
+            recipients: ['that', 'other']
             mailhost: 'localhost'
             port: 1337
             strict: True

--- a/etc/example_egcg.yaml
+++ b/etc/example_egcg.yaml
@@ -35,5 +35,19 @@ default:
         username: a_user
         password: a_password
 
+    notifications:
+        email:
+            sender: 'a_sender'
+            recipients: ['this', 'that', 'other']
+            mailhost: 'localhost'
+            port: 1337
+            strict: True
+
+        asana:
+            access_token: 'an_access_token'
+            workspace_id: 1337
+            project_id: 1338
+
+
 another_env:
   ncbi_cache: 'path/to/ncbi.sqlite'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests>=2.9.1
 pytest>=2.7.2
 PyYAML>=3.11
 genologics>=0.3.2
+jinja2==2.8
+asana==0.5.1

--- a/tests/test_notification_center.py
+++ b/tests/test_notification_center.py
@@ -1,0 +1,81 @@
+import pytest
+from unittest.mock import Mock, patch
+from smtplib import SMTPException
+from egcg_core.notifications import NotificationCentre
+from egcg_core.notifications import EmailNotification, AsanaNotification
+from egcg_core.exceptions import EGCGError
+from tests import TestEGCG
+
+patched_get = patch('egcg_core.rest_communication.get_documents', return_value=[{'run_id': 'test_dataset'}])
+
+
+class FakeSMTP(Mock):
+    def __init__(self, host, port):
+        super().__init__()
+        self.mailhost, self.port = host, port
+
+    @staticmethod
+    def send_message(msg, reporter, recipients):
+        if 'dodgy' in str(msg):
+            raise SMTPException('Oh noes!')
+        else:
+            pass
+
+    @staticmethod
+    def quit():
+        pass
+
+
+class TestNotificationCenter(TestEGCG):
+    def setUp(self):
+        self.notification_center = NotificationCentre('a_name')
+        self.notification_center.setup_subscribers(Mock(), Mock())
+
+    def test_notify(self):
+        self.notification_center.notify('a message')
+        for s in self.notification_center.subscribers:
+            s.notify.assert_called_with('a message')
+
+
+class TestEmailNotification(TestEGCG):
+    def setUp(self):
+        self.email_ntf = EmailNotification('a_name')
+
+    def test_retries(self):
+        with patch('smtplib.SMTP', new=FakeSMTP), patch('egcg_core.notifications.email_notification.sleep'):
+            assert self.email_ntf._try_send(self.email_ntf._prepare_message('this is a test')) is True
+            assert self.email_ntf._try_send(self.email_ntf._prepare_message('dodgy')) is False
+
+            with pytest.raises(EGCGError) as e:
+                self.email_ntf.notify('dodgy')
+                assert 'Failed to send message: dodgy' in str(e)
+
+
+class TestAsanaNotification(TestEGCG):
+    def setUp(self):
+        self.ntf = AsanaNotification('another_name')
+        self.ntf.client = Mock(
+            tasks=Mock(
+                find_all=Mock(return_value=[{'name': 'this'}]),
+                create_in_workspace=Mock(return_value={'id': 1337}),
+                find_by_id=Mock(return_value={'name': 'this', 'id': 1337})
+            )
+        )
+
+    def test_task(self):
+        assert self.ntf._task is None
+        assert self.ntf.task == {'id': 1337, 'name': 'this'}
+        self.ntf.client.tasks.find_by_id.assert_called_with(1337)
+
+    def test_add_comment(self):
+        self.ntf.notify('a comment')
+        self.ntf.client.tasks.add_comment.assert_called_with(1337, text='a comment')
+
+    def test_get_entity(self):
+        collection = [{'name': 'this'}, {'name': 'that'}]
+        assert self.ntf._get_entity(collection, 'that') == {'name': 'that'}
+        assert self.ntf._get_entity(collection, 'other') is None
+
+    def test_create_task(self):
+        assert self.ntf._create_task() == {'id': 1337}
+        self.ntf.client.tasks.create_in_workspace.assert_called_with(1337, self.ntf.task_template)


### PR DESCRIPTION
This adds the ability for any project using EGCG-Core to send notifications. At the moment, three types are supported: local file logging, emails and Asana tasks.

Notification objects can be initialised manually line by line, or with `NotificationCentre`, which registers subscribers based on the contents of a config file. `NotificationCentre` can then call `self.notify` with a message and a list of subscriber names to pass the message to - this way it's possible to control which subscribers handle a given message.

Closes #18.
