### PR TITLE
Toleration of absent config file

### DIFF
--- a/egcg_core/config.py
+++ b/egcg_core/config.py
@@ -6,10 +6,11 @@ from .exceptions import ConfigError
 
 class Configuration:
     config_file = None
-    content = None
+    content = {}
 
     def __init__(self, *search_path):
-        self.load_config_file(self._find_config_file(search_path))
+        if search_path:
+            self.load_config_file(self._find_config_file(search_path))
 
     @staticmethod
     def _find_config_file(search_path):
@@ -22,7 +23,7 @@ class Configuration:
         if self.config_file:
             self.content = yaml.safe_load(open(self.config_file, 'r'))
         else:
-            self.content = None
+            raise ConfigError('Could not find any config file in specified search path')
 
     def get(self, item, ret_default=None):
         """
@@ -79,7 +80,7 @@ class EnvConfiguration(Configuration):
         self._select_env()
 
     def _select_env(self):
-        if self.content and not self.content.get('default'):
+        if not self.content.get('default'):
             raise ConfigError("Could not find 'default' environment in " + self.config_file)
         elif self.content:
             env = getenv(self.env_var, 'default')

--- a/egcg_core/notifications/notification.py
+++ b/egcg_core/notifications/notification.py
@@ -4,7 +4,7 @@ from egcg_core.app_logging import AppLogger
 class Notification(AppLogger):
     preprocess = None
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name):
         self.name = name
 
     def _notify(self, msg):

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -1,6 +1,5 @@
 import requests
 from urllib.parse import urljoin
-from base64 import b64encode
 from egcg_core.config import cfg
 from egcg_core.app_logging import AppLogger
 from egcg_core.exceptions import RestCommunicationError

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -26,7 +26,7 @@ class FakeSMTP(Mock):
         pass
 
 
-class TestNotificationCenter(TestEGCG):
+class TestNotificationCentre(TestEGCG):
     def setUp(self):
         with patch('egcg_core.notifications.NotificationCentre.ntf_aliases',
                    new={'asana': Mock, 'email': Mock}):


### PR DESCRIPTION
`Configuration.content` is now initialised to an empty dict (`{}`) rather than `None`, allowing parts of EGCG-Core to run via `cfg.get` without loading a config file.
Closes #22.
