### PR TITLE
Email flexibility

### DIFF
--- a/egcg_core/notifications/__init__.py
+++ b/egcg_core/notifications/__init__.py
@@ -1,7 +1,7 @@
 from egcg_core.app_logging import AppLogger
 from egcg_core.config import cfg
 from .asana import AsanaNotification
-from .email import EmailNotification, Emailer
+from .email import EmailNotification, send_email
 from .log import LogNotification
 
 

--- a/egcg_core/notifications/__init__.py
+++ b/egcg_core/notifications/__init__.py
@@ -1,7 +1,7 @@
 from egcg_core.app_logging import AppLogger
 from egcg_core.config import cfg
 from .asana import AsanaNotification
-from .email import EmailNotification
+from .email import EmailNotification, Emailer
 from .log import LogNotification
 
 

--- a/egcg_core/notifications/asana.py
+++ b/egcg_core/notifications/asana.py
@@ -14,7 +14,7 @@ class AsanaNotification(Notification):
         if task_description:
             self.task_template['notes'] = task_description
 
-    def _notify(self, msg):
+    def notify(self, msg):
         self.client.tasks.add_comment(self.task['id'], text=msg)
         self.client.tasks.update(self.task['id'], completed=False)
 

--- a/egcg_core/notifications/email.py
+++ b/egcg_core/notifications/email.py
@@ -3,26 +3,28 @@ import smtplib
 from time import sleep
 from email.mime.text import MIMEText
 from egcg_core.exceptions import EGCGError
+from egcg_core.app_logging import AppLogger
 from .notification import Notification
 
 
-class EmailNotification(Notification):
+class Emailer(AppLogger):
     translation_map = {' ': '&nbsp', '\n': '<br/>'}
 
-    def __init__(self, name, mailhost, port, sender, recipients, strict=False, email_template=None):
-        super().__init__(name)
+    def __init__(self, mailhost, port, sender, recipients, default_subject, email_template=None, strict=False):
         self.mailhost = mailhost
         self.port = port
         self.sender = sender
         self.recipients = recipients
-        self.strict = strict
+        self.default_subject = default_subject
         self.email_template = email_template
+        self.strict = strict
 
-    def _notify(self, msg):
-        mail_success = self._try_send(msg)
-        if not mail_success:
+    def send_msg(self, msg, subject=None):
+        email = self.build_email(msg, subject)
+        success = self._try_send(email)
+        if not success:
             err_msg = 'Failed to send message: ' + str(msg)
-            if self.strict is True:
+            if self.strict:
                 raise EGCGError(err_msg)
             else:
                 self.critical(err_msg)
@@ -42,19 +44,24 @@ class EmailNotification(Notification):
             if retries:
                 sleep(2)
                 return self._try_send(msg, retries)
-            else:
-                return False
 
-    def preprocess(self, body):
+            return False
+
+    def build_email(self, body, subject=None):
         """
         Use Jinja to build a MIMEText html-formatted email from plain text.
         :param str body: The main body of the email to send
+        :param str subject: Custom email subject line (default is self.default_subject)
         """
-        content = jinja2.Template(open(self.email_template).read())
-        msg = MIMEText(content.render(title=self.name, body=self._prepare_string(body)), 'html')
-        msg['Subject'] = self.name
+        if self.email_template:
+            content = jinja2.Template(open(self.email_template).read())
+            msg = MIMEText(content.render(title=subject, body=self._prepare_string(body)), 'html')
+        else:
+            msg = MIMEText(body)
+
+        msg['Subject'] = subject or self.default_subject
         msg['From'] = self.sender
-        msg['To'] = ','.join(self.recipients)
+        msg['To'] = ', '.join(self.recipients)
         return msg
 
     @classmethod
@@ -67,3 +74,12 @@ class EmailNotification(Notification):
         connection = smtplib.SMTP(self.mailhost, self.port)
         connection.send_message(msg, self.sender, self.recipients)
         connection.quit()
+
+
+class EmailNotification(Notification):
+    def __init__(self, name, mailhost, port, sender, recipients, email_template=None, strict=False):
+        super().__init__(name)
+        self.emailer = Emailer(mailhost, port, sender, recipients, name, email_template, strict)
+
+    def notify(self, msg):
+        self.emailer.send_msg(msg)

--- a/egcg_core/notifications/log.py
+++ b/egcg_core/notifications/log.py
@@ -17,5 +17,5 @@ class LogNotification(Notification):
         handler.setLevel(logging.INFO)
         self._logger.addHandler(handler)
 
-    def _notify(self, msg):
+    def notify(self, msg):
         self.info(msg)

--- a/egcg_core/notifications/notification.py
+++ b/egcg_core/notifications/notification.py
@@ -5,11 +5,5 @@ class Notification(AppLogger):
     def __init__(self, name):
         self.name = name
 
-    def _notify(self, msg):
-        raise NotImplementedError
-
     def notify(self, msg):
-        self._notify(self.preprocess(msg))
-
-    def preprocess(self, msg):
-        return msg
+        raise NotImplementedError

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2,8 +2,8 @@ from os.path import join, abspath, dirname
 import pytest
 from unittest.mock import Mock, patch
 from smtplib import SMTPException
-from egcg_core.notifications import NotificationCentre
-from egcg_core.notifications import EmailNotification, AsanaNotification
+from email.mime.text import MIMEText
+from egcg_core.notifications import NotificationCentre, Emailer, AsanaNotification
 from egcg_core.exceptions import EGCGError
 from tests import TestEGCG
 
@@ -27,52 +27,84 @@ class FakeSMTP(Mock):
 
 class TestNotificationCentre(TestEGCG):
     def setUp(self):
-        with patch('egcg_core.notifications.NotificationCentre.ntf_aliases',
-                   new={'asana': Mock, 'email': Mock}):
-            self.notification_center = NotificationCentre('a_name')
+        self.notification_centre = NotificationCentre('a_name')
 
     def test_config_init(self):
-        e = self.notification_center.subscribers['email']
-        assert e.sender == 'this'
-        assert e.recipients == ['that', 'other']
-        assert e.mailhost == 'localhost'
-        assert e.port == 1337
-        assert e.strict is True
+        e = self.notification_centre.subscribers['email']
+        assert e.emailer.sender == 'this'
+        assert e.emailer.recipients == ['that', 'other']
+        assert e.emailer.mailhost == 'localhost'
+        assert e.emailer.port == 1337
+        assert e.emailer.strict is True
 
-        a = self.notification_center.subscribers['asana']
+        a = self.notification_centre.subscribers['asana']
         assert a.workspace_id == 1337
         assert a.project_id == 1338
 
     def test_notify(self):
-        self.notification_center.notify_all('a message')
-        for name, s in self.notification_center.subscribers.items():
+        self.notification_centre.subscribers = {'asana': Mock(), 'email': Mock()}
+        self.notification_centre.notify_all('a message')
+        for name, s in self.notification_centre.subscribers.items():
             s.notify.assert_called_with('a message')
 
 
-class TestEmailNotification(TestEGCG):
+class TestEmailSender(TestEGCG):
     def setUp(self):
-        self.email_ntf = EmailNotification(
-            'a_name', sender='a_sender',
-            recipients=['this', 'that', 'other'],
-            mailhost='localhost',
-            port=1337,
-            strict=True,
-            email_template=join(dirname(dirname(abspath(__file__))), 'etc', 'email_notification.html')
+        self.emailer = Emailer(
+            'localhost', 1337, 'a_sender', ['some', 'recipients'], 'a_subject',
+            email_template=join(dirname(dirname(abspath(__file__))), 'etc', 'email_notification.html'),
+            strict=True
         )
 
-    @patch('egcg_core.notifications.EmailNotification._logger')
+    @patch('egcg_core.notifications.Emailer._logger')
     def test_retries(self, mocked_logger):
         with patch('smtplib.SMTP', new=FakeSMTP), patch('egcg_core.notifications.email.sleep'):
-            assert self.email_ntf._try_send(self.email_ntf.preprocess('this is a test')) is True
-            assert self.email_ntf._try_send(self.email_ntf.preprocess('dodgy')) is False
+            assert self.emailer._try_send(self.emailer.build_email('this is a test')) is True
+            assert self.emailer._try_send(self.emailer.build_email('dodgy')) is False
             for i in range(3):
                 mocked_logger.warning.assert_any_call(
                     'Encountered a %s exception. %s retries remaining', 'Oh noes!', i
                 )
 
             with pytest.raises(EGCGError) as e:
-                self.email_ntf.notify('dodgy')
+                self.emailer.send_msg('dodgy')
                 assert 'Failed to send message: dodgy' in str(e)
+
+    def test_build_email(self):
+        exp_msg = (
+            '<!DOCTYPE html>\n'
+            '<html lang="en">\n'
+            '<head>\n'
+            '    <meta charset="UTF-8">\n'
+            '    <style>\n'
+            '        table, th, td {\n'
+            '            border: 1px solid black;\n'
+            '            border-collapse: collapse;\n'
+            '        }\n'
+            '    </style>\n'
+            '</head>\n'
+            '<body>\n'
+            '    <h2>another_subject</h2>\n'
+            '    <p>a&nbspmessage</p>\n'
+            '</body>\n'
+            '</html>'
+        )
+
+        exp = MIMEText(exp_msg, 'html')
+        exp['Subject'] = 'another_subject'
+        exp['From'] = 'a_sender'
+        exp['To'] = 'some, recipients'
+        obs = self.emailer.build_email('a message', 'another_subject')
+        assert str(obs) == str(exp)
+
+    def test_build_email_plain_text(self):
+        self.emailer.email_template = None
+        exp = MIMEText('a message')
+        exp['Subject'] = 'another_subject'
+        exp['From'] = 'a_sender'
+        exp['To'] = 'some, recipients'
+        obs = self.emailer.build_email('a message', 'another_subject')
+        assert str(obs) == str(exp)
 
 
 class TestAsanaNotification(TestEGCG):


### PR DESCRIPTION
Most of EmailNotification's functionality is now in a new class, `Emailer`, which has a little more flexibility than previously. EmailNotification then wraps this object and calls it through `notify`. This way, it should be easier to fire off multiple email messages with different subject lines from the same object.

Notification has also been simplified, and `preprocess` has been removed.

Closes #46.
