### PR TITLE
rest_communication: add option to send data not using json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Changelog for EGCG-Core
 ===========================
 
-0.8 (unreleased)
+0.7.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add new option to rest_communication.post_entry to submit payload without json
 
 
 0.7.2 (2017-08-03)

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -165,9 +165,12 @@ class Communicator(AppLogger):
         else:
             self.warning('No document found in endpoint %s for %s', endpoint, query_args)
 
-    def post_entry(self, endpoint, payload):
+    def post_entry(self, endpoint, payload, use_data=False):
         files, payload = self._detect_files_in_json(payload)
-        return self._req('POST', self.api_url(endpoint), json=payload, files=files)
+        if use_data:
+            return self._req('POST', self.api_url(endpoint), data=payload, files=files)
+        else:
+            return self._req('POST', self.api_url(endpoint), json=payload, files=files)
 
     def put_entry(self, endpoint, element_id, payload):
         files, payload = self._detect_files_in_json(payload)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pytest>=2.7.2
+requests==2.14.2
 PyYAML>=3.11
 pyclarity_lims>=0.4
 jinja2==2.8
-asana==0.6.2
+asana==0.6.5
 cached_property

--- a/tests/test_rest_communication.py
+++ b/tests/test_rest_communication.py
@@ -180,6 +180,24 @@ class TestRestCommunication(TestEGCG):
             files={'f': (file_path, b'test content', 'text/plain')}
         )
 
+        self.comm.post_entry(test_endpoint, payload=test_flat_request_content, use_data=True)
+        mocked_response.assert_called_with(
+            'POST',
+            rest_url(test_endpoint),
+            auth=auth,
+            data=test_flat_request_content,
+            files=None
+        )
+
+        self.comm.post_entry(test_endpoint, payload=test_request_content_plus_files, use_data=True)
+        mocked_response.assert_called_with(
+            'POST',
+            rest_url(test_endpoint),
+            auth=auth,
+            data=test_flat_request_content,
+            files={'f': (file_path, b'test content', 'text/plain')}
+        )
+
     @patched_response
     def test_put_entry(self, mocked_response):
         self.comm.put_entry(test_endpoint, 'an_element_id', payload=test_nested_request_content)


### PR DESCRIPTION
Add new option to post_entry to allow the use of the data field in requests
also update the requirements.txt
fixes #59