### PR TITLE
Dict querying

### DIFF
--- a/egcg_core/util.py
+++ b/egcg_core/util.py
@@ -100,3 +100,22 @@ def move_dir(src_dir, dest_dir):
             dest_file = os.path.join(dest_dir, os.path.basename(src_file))
             shutil.move(fp, dest_file)
     return 0
+
+
+def query_dict(data, query_string):
+    """
+    Drill down into a dict using dot notation, e.g. query_dict({'this': {'that': 'other'}}, 'this.that'}).
+    :param dict data:
+    :param str query_string:
+    """
+    _data = data.copy()
+
+    for q in query_string.split('.'):
+        d = _data.get(q)
+        if d is None:
+            return None
+
+        else:
+            _data = d
+
+    return _data

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -74,7 +74,6 @@ class TestMoveDir(TestEGCG):
 
     def setUp(self):
         self.test_dir = join(self.assets_path, 'move_dir')
-        makedirs(join(self.test_dir, 'from'), exist_ok=True)
         makedirs(join(self.test_dir, 'from', 'subdir'), exist_ok=True)
         self._create_test_file(join(self.test_dir, 'from', 'ftest.txt'))
         self._create_test_file(join(self.test_dir, 'from', 'subdir', 'ftest.txt'))
@@ -83,7 +82,6 @@ class TestMoveDir(TestEGCG):
         self._create_test_file(join(self.test_dir, 'external', 'external.txt'), 'External file')
         symlink(join(self.test_dir, 'external', 'external.txt'), join(self.test_dir, 'from', 'external_renamed.txt'))
 
-        makedirs(join(self.test_dir, 'exists'), exist_ok=True)
         makedirs(join(self.test_dir, 'exists', 'subdir'), exist_ok=True)
         self._create_test_file(join(self.test_dir, 'exists', 'subdir', 'ftest.txt'), 'another file')
         self._create_test_file(join(self.test_dir, 'exists', 'ftest.txt'), 'another file')
@@ -127,3 +125,10 @@ class TestMoveDir(TestEGCG):
         assert util.find_file(to, 'ftest.txt')
         assert md5_from1 == self._md5(join(to, 'ftest.txt'))
         assert md5_from2 == self._md5(join(to, 'subdir', 'ftest.txt'))
+
+
+def test_query_dict():
+    data = {'this': {'that': 'other'}}
+    assert util.query_dict(data, 'this') == {'that': 'other'}
+    assert util.query_dict(data, 'this.that') == 'other'
+    assert util.query_dict(data, 'nonexistent') is None


### PR DESCRIPTION
Adds a common function for drilling down into a nested dictionary with a dot-separated query string:
```python
data = {'this': {'that': 1}}
util.query_dict(data, 'this.that')  # returns 1
util.query_dict(data, 'this.non_existent')  # returns None
```
Closes #68.
