### PR TITLE
rest_communication retries, issue cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - "pip install -r requirements.txt"
   - "pip install python-coveralls pytest-cov"
   - "python setup.py install"
-script: py.test tests/ --doctest-modules  -v --cov egcg_core --cov-report term-missing
+script: py.test tests/ --cov egcg_core --cov-report term-missing
 after_success:
   - coveralls
 # branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Changelog for EGCG-Core
 0.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Breaking change: removed `clarity.get_expected_yield_for_sample`
+- Catching notification failures
+- Added retries to `rest_communication`
+- Added log warnings to `util.find_file`
 
 
 0.8.2 (2018-05-28)

--- a/egcg_core/clarity.py
+++ b/egcg_core/clarity.py
@@ -206,19 +206,6 @@ def get_sample_genotype(sample_name, output_file_name):
             app_logger.warning('Cannot download genotype results for %s', sample_name)
 
 
-def get_expected_yield_for_sample(sample_name):
-    """
-    Query the LIMS and return the number of bases expected for a sample
-    :param sample_name: the sample name
-    :return: number of bases
-    """
-    sample = get_sample(sample_name)
-    if sample:
-        nb_gb = sample.udf.get('Yield for Quoted Coverage (Gb)')
-        if nb_gb:
-            return nb_gb * 1000000000
-
-
 def get_plate_id_and_well(sample_name):
     sample = get_sample(sample_name)
     if sample:

--- a/egcg_core/ncbi.py
+++ b/egcg_core/ncbi.py
@@ -36,6 +36,9 @@ def get_species_name(query_species):
         q, taxid, scientific_name, common_name = local_query
     else:
         taxid, scientific_name, common_name = _fetch_from_eutils(query_species)
+        if taxid is None:
+            return None
+
         _cache_species(query_species, taxid, scientific_name, common_name)
 
     return scientific_name

--- a/egcg_core/notifications/__init__.py
+++ b/egcg_core/notifications/__init__.py
@@ -1,5 +1,8 @@
+import sys
+import traceback
 from egcg_core.app_logging import AppLogger
 from egcg_core.config import cfg
+from egcg_core.exceptions import EGCGError
 from .asana import AsanaNotification
 from .email import EmailNotification, EmailSender, send_email, send_html_email, send_plain_text_email
 from .log import LogNotification
@@ -16,21 +19,32 @@ class NotificationCentre(AppLogger):
         self.name = name
         self.subscribers = {}
 
-        for s in cfg.get('notifications', {}):
-            if s in self.ntf_aliases:
-                self.debug('Configuring notification for: ' + s)
-                config = cfg['notifications'][s]
-                self.subscribers[s] = self.ntf_aliases[s](name=self.name, **config)
+        for k, v in cfg.get('notifications', {}).items():
+            if k in self.ntf_aliases:
+                self.debug('Configuring notification for: ' + k)
+                self.subscribers[k] = self.ntf_aliases[k](name=self.name, **v)
             else:
-                self.warning("Bad notification config '%s' - this will be ignored", s)
+                self.warning("Bad notification config '%s' - this will be ignored", k)
 
     def notify(self, msg, subs):
+        exceptions = []
         for s in subs:
             if s in self.subscribers:
-                self.subscribers[s].notify(msg)
+                try:
+                    self.subscribers[s].notify(msg)
+                except Exception as e:
+                    etype, value, tb = sys.exc_info()
+                    stacktrace = ''.join(traceback.format_exception(etype, value, tb))
+                    self.critical(stacktrace)
+                    exceptions.append(e)
             else:
                 self.debug('Tried to notify by %s, but no configuration present', s)
 
+        if exceptions:
+            raise EGCGError(
+                'Encountered the following errors during notification: %s' % ', '.join(
+                    '%s: %s' % (e.__class__.__name__, str(e)) for e in exceptions)
+            )
+
     def notify_all(self, msg):
-        for s in self.subscribers.values():
-            s.notify(msg)
+        self.notify(msg, self.subscribers.keys())

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -43,8 +43,7 @@ class Communicator(AppLogger):
     @staticmethod
     def serialise(queries):
         serialised_queries = {}
-        for k in sorted(queries):
-            v = queries[k]
+        for k, v in queries.items():
             serialised_queries[k] = json.dumps(v) if isinstance(v, dict) else v
         return serialised_queries
 

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -43,7 +43,8 @@ class Communicator(AppLogger):
     @staticmethod
     def serialise(queries):
         serialised_queries = {}
-        for k, v in queries.items():
+        for k in sorted(queries):
+            v = queries[k]
             serialised_queries[k] = json.dumps(v) if isinstance(v, dict) else v
         return serialised_queries
 

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -1,7 +1,9 @@
 import json
 import mimetypes
-import requests
 from urllib.parse import urljoin
+import requests
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 from egcg_core.config import cfg
 from egcg_core.app_logging import AppLogger
 from egcg_core.exceptions import RestCommunicationError
@@ -11,9 +13,24 @@ from egcg_core.util import check_if_nested
 class Communicator(AppLogger):
     successful_statuses = (200, 201, 202, 204)
 
-    def __init__(self, auth=None, baseurl=None):
+    def __init__(self, auth=None, baseurl=None, retries=5):
         self._baseurl = baseurl
         self._auth = auth
+        self.retries = retries
+        self.session = self.begin_session()
+
+    def begin_session(self):
+        s = requests.Session()
+        adapter = HTTPAdapter(max_retries=Retry(self.retries, self.retries, self.retries, backoff_factor=0.2))
+        s.mount('http://', adapter)
+        s.mount('https://', adapter)
+
+        if isinstance(self.auth, tuple):
+            s.auth = self.auth
+        elif isinstance(self.auth, str):
+            s.headers.update({'Authorization': 'Token %s' % self.auth})
+
+        return s
 
     @staticmethod
     def serialise(queries):
@@ -103,11 +120,6 @@ class Communicator(AppLogger):
         return query
 
     def _req(self, method, url, quiet=False, **kwargs):
-        if isinstance(self.auth, tuple):
-            kwargs['auth'] = self.auth
-        elif isinstance(self.auth, str):
-            kwargs['headers'] = dict(kwargs.get('headers', {}), Authorization='Token %s' % self.auth)
-
         # can't upload json and files at the same time, so we need to move the json parameter to data
         # data can't upload complex structures that would require json encoding.
         # this means we can't upload data with nested lists/dicts at the same time as files
@@ -116,10 +128,8 @@ class Communicator(AppLogger):
                 raise RestCommunicationError('Cannot upload files and nested json in one query')
             kwargs['data'] = kwargs.pop('json')
 
-        r = requests.request(method, url, **kwargs)
+        r = self.session.request(method, url, **kwargs)
 
-        kwargs.pop('auth', None)
-        kwargs.pop('headers', None)
         kwargs.pop('files', None)
         # e.g: 'POST <url> ({"some": "args"}) -> {"some": "content"}. Status code 201. Reason: CREATED
         report = '%s %s (%s) -> %s. Status code %s. Reason: %s' % (

--- a/egcg_core/util.py
+++ b/egcg_core/util.py
@@ -26,7 +26,10 @@ def find_files(*path_parts):
 
 def find_file(*path_parts):
     files = find_files(*path_parts)
-    if files:
+    nfiles = len(files)
+    if nfiles > 1:
+        app_logger.warning('Searched pattern %s for one file, but got %s', path_parts, nfiles)
+    elif nfiles == 1:
         return files[0]
 
 

--- a/egcg_core/util.py
+++ b/egcg_core/util.py
@@ -102,20 +102,20 @@ def move_dir(src_dir, dest_dir):
     return 0
 
 
-def query_dict(data, query_string):
+def query_dict(data, query_string, ret_default=None):
     """
     Drill down into a dict using dot notation, e.g. query_dict({'this': {'that': 'other'}}, 'this.that'}).
     :param dict data:
     :param str query_string:
+    :param ret_default:
     """
     _data = data.copy()
 
     for q in query_string.split('.'):
         d = _data.get(q)
-        if d is None:
-            return None
-
-        else:
+        if d is not None:
             _data = d
+        else:
+            return ret_default
 
     return _data

--- a/tests/test_clarity.py
+++ b/tests/test_clarity.py
@@ -178,11 +178,6 @@ class TestClarity(TestEGCG):
         assert open(genotype_vcf).read() == 'some test content'
         os.remove(genotype_vcf)
 
-    @patched_clarity('get_sample', Mock(udf={'Yield for Quoted Coverage (Gb)': 3}))
-    def test_get_expected_yield_for_sample(self, mocked_get_sample):
-        assert clarity.get_expected_yield_for_sample('a_sample_id') == 3000000000
-        mocked_get_sample.assert_called_with('a_sample_id')
-
     @patched_lims('get_processes', ['a_run'])
     def test_get_run(self, mocked_lims):
         assert clarity.get_run('a_run_id') == 'a_run'

--- a/tests/test_rest_communication.py
+++ b/tests/test_rest_communication.py
@@ -1,8 +1,7 @@
 import os
 import json
-import pytest
 from requests import Session
-from unittest.mock import patch
+from unittest.mock import Mock, patch, call
 from tests import FakeRestResponse, TestEGCG
 from egcg_core import rest_communication
 from egcg_core.util import check_if_nested
@@ -11,10 +10,6 @@ from egcg_core.exceptions import RestCommunicationError
 
 def rest_url(endpoint):
     return 'http://localhost:4999/api/0.1/' + endpoint + '/'
-
-
-def ppath(extension):
-    return 'egcg_core.rest_communication.Communicator.' + extension
 
 
 test_endpoint = 'an_endpoint'
@@ -65,13 +60,13 @@ class TestRestCommunication(TestEGCG):
             'this': 'that', 'other': '{"another":"more"}', 'things': '1'
         }
 
-        with pytest.raises(RestCommunicationError) as e:
+        with self.assertRaises(RestCommunicationError) as e:
             self.comm._parse_query_string(dodgy_query_string)
-            assert str(e) == 'Bad query string: ' + dodgy_query_string
+            assert str(e.exception) == 'Bad query string: ' + dodgy_query_string
 
-        with pytest.raises(RestCommunicationError) as e2:
+        with self.assertRaises(RestCommunicationError) as e2:
             self.comm._parse_query_string(query_string, requires=['thangs'])
-            assert str(e2) == query_string + " did not contain all required fields: ['thangs']"
+            assert str(e2.exception) == query_string + " did not contain all required fields: ['thangs']"
 
     def test_detect_files_in_json(self):
         json_no_files = {'k1': 'v1', 'k2': 'v2'}
@@ -102,37 +97,63 @@ class TestRestCommunication(TestEGCG):
             assert json.loads(response.content.decode('utf-8')) == response.json() == test_nested_request_content
             mocked_request.assert_called_with('METHOD', rest_url(test_endpoint), json=json_content)
 
-    @patch.object(Session, 'close')
+    @patch.object(Session, '__exit__')
+    @patch.object(Session, '__enter__')
     @patched_request
-    def test_context_manager(self, mocked_request, mocked_close):
+    def test_context_manager(self, mocked_request, mocked_enter, mocked_exit):
         json_content = ['some', {'test': 'json'}]
         with self.comm.session:
-            for i in range(4):
+            mocked_enter.assert_called_once()
+            mocked_exit.assert_not_called()
+            for i in range(4):  # multiple calls
                 response = self.comm._req('METHOD', rest_url(test_endpoint), json=json_content)
                 assert response.status_code == 200
                 assert response.json() == test_nested_request_content
                 mocked_request.assert_called_with('METHOD', rest_url(test_endpoint), json=json_content)
 
-        assert mocked_close.call_count == 1
+        assert mocked_request.call_count == 4
+        mocked_exit.assert_called_once()
 
-    def test_get_documents_depaginate(self):
-        docs = (
+    @patch.object(rest_communication.Communicator, 'error')
+    @patch.object(Session, 'request')
+    def test_communication_error(self, mocked_req, mocked_log):
+        response = FakeRestResponse({})
+        response.status_code = 500
+        mocked_req.return_value = response
+        self.comm.lock = Mock()
+        self.comm.lock.acquire.assert_not_called()
+        self.comm.lock.release.assert_not_called()
+
+        with self.assertRaises(RestCommunicationError) as e:
+            self.comm.get_document('an_endpoint')
+
+        mocked_log.assert_called_with(
+            "a method a url ({'params': {'max_results': 100, 'page': 1}}) -> {}. Status code 500. Reason: a reason"
+        )
+        assert str(e.exception) == 'Encountered a 500 status code: a reason'
+        self.comm.lock.acquire.assert_called_once()
+        self.comm.lock.release.assert_called_once()  # exception raised, but lock still released
+
+    @patch.object(rest_communication.Communicator, '_req')
+    def test_get_documents_depaginate(self, mocked_req):
+        mocked_req.side_effect = (
             FakeRestResponse({'data': ['this', 'that'], '_links': {'next': {'href': 'an_endpoint?max_results=101&page=2'}}}),
             FakeRestResponse({'data': ['other', 'another'], '_links': {'next': {'href': 'an_endpoint?max_results=101&page=3'}}}),
             FakeRestResponse({'data': ['more', 'things'], '_links': {}})
         )
-        with patch(ppath('_req'), side_effect=docs) as mocked_req:
-            assert self.comm.get_documents('an_endpoint', all_pages=True, max_results=101) == [
-                'this', 'that', 'other', 'another', 'more', 'things'
-            ]
-            assert all([a[0][1].startswith(rest_url('an_endpoint')) for a in mocked_req.call_args_list])
-            assert [a[1] for a in mocked_req.call_args_list] == [
+
+        assert self.comm.get_documents('an_endpoint', all_pages=True, max_results=101) == [
+            'this', 'that', 'other', 'another', 'more', 'things'
+        ]
+        mocked_req.assert_has_calls(
+            (
                 # Communicator.get_content passes ints
-                {'params': {'page': 1, 'max_results': 101}, 'quiet': False},
+                call('GET', rest_url('an_endpoint'), params={'page': 1, 'max_results': 101}, quiet=False),
                 # url parsing passes strings, but requests removes the quotes anyway
-                {'params': {'page': '2', 'max_results': '101'}, 'quiet': False},
-                {'params': {'page': '3', 'max_results': '101'}, 'quiet': False}
-            ]
+                call('GET', rest_url('an_endpoint'), params={'page': '2', 'max_results': '101'}, quiet=False),
+                call('GET', rest_url('an_endpoint'), params={'page': '3', 'max_results': '101'}, quiet=False)
+            )
+        )
 
         docs = [
             FakeRestResponse(
@@ -145,9 +166,9 @@ class TestRestCommunication(TestEGCG):
         ]
         docs.append(FakeRestResponse({'data': ['last piece'], '_links': {}}))
 
-        with patch(ppath('_req'), side_effect=docs):
-            ret = self.comm.get_documents('an_endpoint', all_pages=True, max_results=101)
-            assert len(ret) == 1200
+        mocked_req.side_effect = docs
+        ret = self.comm.get_documents('an_endpoint', all_pages=True, max_results=101)
+        assert len(ret) == 1200
 
     @patched_request
     def test_get_content(self, mocked_request):
@@ -227,7 +248,7 @@ class TestRestCommunication(TestEGCG):
             files={'f': (file_path, b'test content', 'text/plain')}
         )
 
-    @patch(ppath('get_document'), return_value=test_patch_document)
+    @patch.object(rest_communication.Communicator, 'get_document', return_value=test_patch_document)
     @patched_request
     def test_patch_entry(self, mocked_request, mocked_get_doc):
         patching_payload = {'list_to_update': ['another']}
@@ -248,7 +269,7 @@ class TestRestCommunication(TestEGCG):
             files=None
         )
 
-    @patch(ppath('get_document'), return_value=test_patch_document)
+    @patch.object(rest_communication.Communicator, 'get_document', return_value=test_patch_document)
     @patched_request
     def test_if_match(self, mocked_request, mocked_get_doc):
         self.comm.patch_entry(test_endpoint, {'this': 'that'}, 'uid', 'a_unique_id')
@@ -261,38 +282,37 @@ class TestRestCommunication(TestEGCG):
             files=None
         )
 
-    def test_post_or_patch(self):
+    @patch.object(rest_communication.Communicator, 'post_entry', return_value=True)
+    @patch.object(rest_communication.Communicator, '_patch_entry', return_value=True)
+    @patch.object(rest_communication.Communicator, 'get_document')
+    def test_post_or_patch(self, mocked_get, mocked_patch, mocked_post):
         test_post_or_patch_payload = {'uid': '1337', 'list_to_update': ['more'], 'another_field': 'that'}
         test_post_or_patch_payload_no_uid = {'list_to_update': ['more'], 'another_field': 'that'}
         test_post_or_patch_doc = {
             'uid': 'a_uid', '_id': '1337', '_etag': 1234567, 'list_to_update': ['things'], 'another_field': 'this'
         }
-        patched_post = patch(ppath('post_entry'), return_value=True)
-        patched_patch = patch(ppath('_patch_entry'), return_value=True)
-        patched_get = patch(ppath('get_document'), return_value=test_post_or_patch_doc)
-        patched_get_none = patch(ppath('get_document'), return_value=None)
+        mocked_get.return_value = test_post_or_patch_doc
 
-        with patched_get as mget, patched_patch as mpatch:
-            self.comm.post_or_patch(
-                'an_endpoint',
-                [test_post_or_patch_payload],
-                id_field='uid',
-                update_lists=['list_to_update']
-            )
-            mget.assert_called_with('an_endpoint', where={'uid': '1337'})
-            mpatch.assert_called_with(
-                'an_endpoint',
-                test_post_or_patch_doc,
-                test_post_or_patch_payload_no_uid,
-                ['list_to_update']
-            )
+        self.comm.post_or_patch(
+            'an_endpoint',
+            [test_post_or_patch_payload],
+            id_field='uid',
+            update_lists=['list_to_update']
+        )
+        mocked_get.assert_called_with('an_endpoint', where={'uid': '1337'})
+        mocked_patch.assert_called_with(
+            'an_endpoint',
+            test_post_or_patch_doc,
+            test_post_or_patch_payload_no_uid,
+            ['list_to_update']
+        )
 
-        with patched_get_none as mget, patched_post as mpost:
-            self.comm.post_or_patch(
-                'an_endpoint', [test_post_or_patch_payload], id_field='uid', update_lists=['list_to_update']
-            )
-            mget.assert_called_with('an_endpoint', where={'uid': '1337'})
-            mpost.assert_called_with('an_endpoint', test_post_or_patch_payload)
+        mocked_get.return_value = None
+        self.comm.post_or_patch(
+            'an_endpoint', [test_post_or_patch_payload], id_field='uid', update_lists=['list_to_update']
+        )
+        mocked_get.assert_called_with('an_endpoint', where={'uid': '1337'})
+        mocked_post.assert_called_with('an_endpoint', test_post_or_patch_payload)
 
 
 def test_default():

--- a/tests/test_rest_communication.py
+++ b/tests/test_rest_communication.py
@@ -127,9 +127,7 @@ class TestRestCommunication(TestEGCG):
         with self.assertRaises(RestCommunicationError) as e:
             self.comm.get_document('an_endpoint')
 
-        mocked_log.assert_called_with(
-            "a method a url ({'params': {'max_results': 100, 'page': 1}}) -> {}. Status code 500. Reason: a reason"
-        )
+        assert mocked_log.call_args[0][0].endswith('Status code 500. Reason: a reason')
         assert str(e.exception) == 'Encountered a 500 status code: a reason'
         self.comm.lock.acquire.assert_called_once()
         self.comm.lock.release.assert_called_once()  # exception raised, but lock still released

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -132,3 +132,4 @@ def test_query_dict():
     assert util.query_dict(data, 'this') == {'that': 'other'}
     assert util.query_dict(data, 'this.that') == 'other'
     assert util.query_dict(data, 'nonexistent') is None
+    assert util.query_dict(data, 'nonexistent', ret_default='things') == 'things'


### PR DESCRIPTION
💥💥💥💥💥🔨
- Closes #71 - removed `clarity.get_expected_yield_for_sample`
- Closes #74 - adding `ret_default` to `util.query_dict`
- Closes #75 - adding internal session object to Communicator
- Closes #79 - catching/re-raising errors during notification
- Closes #80 - immediately returning nothing from `ncbi.get_species_name` if Eutils returns nothing
- Logging a warning if `util.find_file` finds multiple files