### PR TITLE
Dependencies, job queues, small fixes

### DIFF
--- a/egcg_core/config.py
+++ b/egcg_core/config.py
@@ -27,7 +27,9 @@ class Configuration:
             self.env_var = env_var
         self.config_file = self._find_config_file(search_path)
         if self.config_file:
-            self.content = yaml.safe_load(open(self.config_file, 'r'))
+            with open(self.config_file, 'r') as f:
+                self.content = yaml.safe_load(f)
+
             self._select_env()
         else:
             raise ConfigError('Could not find any config file in specified search path')

--- a/egcg_core/executor/array_executor.py
+++ b/egcg_core/executor/array_executor.py
@@ -36,6 +36,6 @@ class ArrayExecutor(StreamExecutor):
         if self.exception:
             self._stop()
             self.error(self.exception.__class__.__name__ + ': ' + str(self.exception))
-            raise EGCGError('Commands failed: ' + str(self.exit_statuses))
+            raise EGCGError('Commands failed: ' + str(self.exit_statuses)) from self.exception
         self.info('Exit statuses: %s', self.exit_statuses)
         return sum(self.exit_statuses)

--- a/egcg_core/executor/cluster_executor.py
+++ b/egcg_core/executor/cluster_executor.py
@@ -27,10 +27,10 @@ class ClusterExecutor(AppLogger):
         """
         self.interval = cfg.query('executor', 'join_interval', ret_default=30)
         self.job_id = None
-        self.job_name = cluster_config.get('job_name')
+        self.job_name = cluster_config['job_name']
         self.cmds = cmds
         self.prelim_cmds = prelim_cmds
-        self.writer = self._get_writer(job_queue=cfg['executor']['job_queue'], **cluster_config)
+        self.writer = self._get_writer(**cluster_config)
 
     def write_script(self):
         if self.prelim_cmds:
@@ -60,8 +60,16 @@ class ClusterExecutor(AppLogger):
         running_executors.pop(self.job_id, None)  # unregister from running_executors
         return self._job_exit_code()
 
-    def _get_writer(self, job_name, working_dir, job_queue, walltime=None, cpus=1, mem=2, log_commands=True):
-        return self.script_writer(job_name, working_dir, job_queue, log_commands=log_commands, cpus=cpus, mem=mem, walltime=walltime)
+    def _get_writer(self, job_name, working_dir, job_queue=None, cpus=1, mem=2, walltime=None, log_commands=True):
+        return self.script_writer(
+            job_name,
+            working_dir,
+            job_queue or cfg['executor']['job_queue'],
+            cpus,
+            mem,
+            walltime,
+            log_commands
+        )
 
     def _job_statuses(self):
         return ()

--- a/egcg_core/executor/executor.py
+++ b/egcg_core/executor/executor.py
@@ -1,5 +1,4 @@
 import subprocess
-import shlex
 from egcg_core.app_logging import AppLogger
 from egcg_core.exceptions import EGCGError
 
@@ -35,6 +34,5 @@ class Executor(AppLogger):
         :rtype: subprocess.Popen
         """
         self.info('Executing: %s', self.cmd)
-        # TODO: explore how to run commands with Bash constructs , e.g. 'command <(sub command)'
-        self.proc = subprocess.Popen(shlex.split(self.cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         return self.proc

--- a/egcg_core/executor/executor.py
+++ b/egcg_core/executor/executor.py
@@ -24,8 +24,15 @@ class Executor(AppLogger):
         except Exception as e:
             raise EGCGError('Command failed: ' + self.cmd) from e
 
-    def start(self):
-        raise NotImplementedError
+    @staticmethod
+    def start():
+        """
+        Subclasses of Executor implement this method from different sources:
+          - StreamExecutor and ArrayExecutor inherit it from threading.Thread
+          - ClusterExecutor implements it so it writes and submits a script to a queue
+        The definition here has no effect, but allows Executor to be handled identically to other executors.
+        """
+        pass
 
     def _process(self):
         """

--- a/egcg_core/executor/stream_executor.py
+++ b/egcg_core/executor/stream_executor.py
@@ -21,7 +21,7 @@ class StreamExecutor(Thread, Executor):
         super().join(timeout=timeout)
         if self.exception:
             self._stop()
-            self.error('Encountered a %s error: %s', self.exception.__class__.__name__, str(self.exception))
+            self.error('Encountered a %s error: %s', self.exception.__class__.__name__, self.exception)
             raise EGCGError('self.proc command failed: ' + self.cmd)
         return self.proc.wait()
 
@@ -32,9 +32,7 @@ class StreamExecutor(Thread, Executor):
             self.exception = e
 
     def _stream_output(self):
-        """
-        Run self._process and log its stdout/stderr until an EOF.
-        """
+        """Run self._process and log its stdout/stderr until an EOF."""
         proc = self._process()
         read_set = [proc.stdout, proc.stderr]
         while read_set:

--- a/egcg_core/executor/stream_executor.py
+++ b/egcg_core/executor/stream_executor.py
@@ -22,7 +22,8 @@ class StreamExecutor(Thread, Executor):
         if self.exception:
             self._stop()
             self.error('Encountered a %s error: %s', self.exception.__class__.__name__, self.exception)
-            raise EGCGError('self.proc command failed: ' + self.cmd)
+            raise EGCGError('Command failed: ' + self.cmd) from self.exception
+
         return self.proc.wait()
 
     def run(self):

--- a/egcg_core/integration_testing.py
+++ b/egcg_core/integration_testing.py
@@ -4,8 +4,9 @@ from os import getenv
 from time import sleep
 from datetime import datetime
 from unittest import TestCase
-from egcg_core import config, rest_communication
+from multiprocessing import Lock
 from subprocess import check_output
+from egcg_core import config, rest_communication
 
 
 def get_cfg():
@@ -26,6 +27,7 @@ class WrappedFunc:
     def __init__(self, test_case, assert_func):
         self.test_case = test_case
         self.assert_func = assert_func
+        self.lock = Lock()
 
     def __call__(self, check_name, *args, **kwargs):
         if not isinstance(check_name, str):
@@ -48,10 +50,10 @@ class WrappedFunc:
             self.log(assertion_report + 'failed' + args_used)
             raise
 
-    @staticmethod
-    def log(msg):
-        with open('checks.log', 'a') as f:
-            f.write(msg + '\n')
+    def log(self, msg):
+        with self.lock:
+            with open('checks.log', 'a') as f:
+                f.write(msg + '\n')
 
 
 class IntegrationTest(TestCase):

--- a/egcg_core/notifications/__init__.py
+++ b/egcg_core/notifications/__init__.py
@@ -43,7 +43,9 @@ class NotificationCentre(AppLogger):
         if exceptions:
             raise EGCGError(
                 'Encountered the following errors during notification: %s' % ', '.join(
-                    '%s: %s' % (e.__class__.__name__, str(e)) for e in exceptions)
+                    '%s: %s' % (e.__class__.__name__, str(e))
+                    for e in exceptions
+                )
             )
 
     def notify_all(self, msg):

--- a/egcg_core/rest_communication.py
+++ b/egcg_core/rest_communication.py
@@ -267,7 +267,7 @@ class Communicator(AppLogger):
     def __del__(self):
         try:
             self.close()
-        except ReferenceError:
+        except Exception:
             pass
 
 default = Communicator()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-pytest>=3.0.0
+pytest==4.1.1
 pytest_xdist==1.24.1
-pytest_cov>=2.5.1
+pytest_cov==2.6.0
 requests==2.20.0
-PyYAML>=3.11
-pyclarity_lims>=0.4
+PyYAML==3.13
+pyclarity_lims==0.4.5
 jinja2==2.8
 asana==0.6.7
-cached_property
+cached_property==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest>=3.0.0
-pytest_xdist==1.24.1  #
+pytest_xdist==1.24.1
 pytest_cov>=2.5.1
 requests==2.20.0
 PyYAML>=3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pytest>=2.7.2
-pytest_xdist>=1.22.2
+pytest>=3.0.0
+pytest_xdist==1.24.1  #
 pytest_cov>=2.5.1
-requests==2.14.2
+requests==2.20.0
 PyYAML>=3.11
 pyclarity_lims>=0.4
 jinja2==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest==4.1.1
 pytest_xdist==1.24.1
-pytest_cov==2.6.0
+pytest_cov==2.6.1
 requests==2.20.0
 PyYAML==3.13
 pyclarity_lims==0.4.5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import json
 import os.path
 import unittest
 from unittest.mock import Mock
+from egcg_core.config import cfg
 
 
 class FakeRestResponse(Mock):
@@ -26,3 +27,7 @@ class TestEGCG(unittest.TestCase):
     assets_path = os.path.join(file_path, 'assets')
     etc = os.path.join(os.path.dirname(file_path), 'etc')
     etc_config = os.path.join(etc, 'example_egcg.yaml')
+
+    @classmethod
+    def setUpClass(cls):
+        cfg.load_config_file(cls.etc_config)

--- a/tests/test_app_logging.py
+++ b/tests/test_app_logging.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 from tests import TestEGCG
 from egcg_core import app_logging
 from egcg_core.config import cfg
-cfg.load_config_file(TestEGCG.etc_config)
 
 
 class TestLoggingConfiguration(TestEGCG):

--- a/tests/test_clarity.py
+++ b/tests/test_clarity.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import patch, Mock
 from egcg_core import clarity
-from egcg_core.config import cfg
 from tests import TestEGCG
 
 
@@ -62,7 +61,6 @@ class TestClarity(TestEGCG):
         clarity.app_logger = Mock()
 
     def test_connection(self):
-        cfg.load_config_file(self.etc_config)
         clarity._lims = None
         # create connection from config
         lims = clarity.connection()

--- a/tests/test_executor/test_executors.py
+++ b/tests/test_executor/test_executors.py
@@ -13,63 +13,93 @@ sleep = 'egcg_core.executor.cluster_executor.sleep'
 
 
 class TestExecutor(TestEGCG):
+    executor_cls = Executor
+
+    def execute(self, *args, **kwargs):
+        e = self.executor_cls(*args, **kwargs)
+        try:
+            e.start()
+        except NotImplementedError:
+            pass
+
+        return e.join()
+
     def test_cmd(self):
-        e = Executor('ls ' + os.path.join(self.assets_path, '..'))
-        exit_status = e.join()
-        assert exit_status == 0
+        assert self.execute('ls ' + os.path.dirname(self.assets_path)) == 0
 
     def test_dodgy_cmd(self):
-        with pytest.raises(EGCGError) as err:
-            e = Executor('dodgy_cmd')
-            e.join()
-            assert 'Command failed: \'dodgy_cmd\'' in str(err)
+        assert self.execute('dodgy_cmd') == 127
+
+    def test_script(self):
+        assert self.execute(os.path.join(self.assets_path, 'countdown.sh')) == 0
+
+    def test_dodgy_script(self):
+        # same exit status as the running script
+        assert self.execute('%s dodgy' % os.path.join(self.assets_path, 'countdown.sh')) == 13
+
+    def test_internal_error(self):
+        with patch.object(self.executor_cls, 'info', side_effect=ValueError('Something went wrong')):
+            with pytest.raises(EGCGError) as err:
+                self.execute('ls')
+
+            assert 'Command failed: ls' in str(err)
 
     def test_process(self):
-        e = Executor('ls ' + os.path.join(self.assets_path, '..'))
+        e = self.executor_cls('ls ' + os.path.dirname(self.assets_path))
         assert e.proc is None
         proc = e._process()
         assert proc is e.proc and isinstance(e.proc, subprocess.Popen)
 
+    def test_bash_syntax(self):
+        with patch.object(self.executor_cls, 'info') as mocked_info:
+            assert self.execute('ls -lh %s | grep __init__' % os.path.dirname(self.assets_path)) == 0
+
+        assert '__init__.py' in mocked_info.call_args_list[1][0][0]
+
 
 class TestStreamExecutor(TestExecutor):
-    def test_cmd(self):
-        e = StreamExecutor(os.path.join(self.assets_path, 'countdown.sh'))
-        e.start()
-        assert e.join() == 0
-
-    def test_dodgy_command(self):
-        e = StreamExecutor(os.path.join(self.assets_path, 'countdown.sh') + ' dodgy')
-        e.start()
-        assert e.join() == 13  # same exit status as the running script
-
-    def test_dodgy_cmd(self):
-        with pytest.raises(EGCGError) as err:
-            e = StreamExecutor('dodgy_cmd')
-            e.start()
-            e.error = Mock()
-            e.join()
-            assert 'self.proc command failed: \'dodgy_cmd\'' in str(err)
+    executor_cls = StreamExecutor
 
 
 class TestArrayExecutor(TestExecutor):
+    executor_cls = ArrayExecutor
+
+    def execute(self, *args, **kwargs):
+        return super().execute(args, stream=True, **kwargs)
+
     def test_cmd(self):
-        e = ArrayExecutor(['ls', 'ls -lh', 'pwd'], stream=True)
+        e = self.executor_cls(['ls', 'ls -lh', 'pwd'], stream=True)
         e.start()
         assert e.join() == 0
         assert e.exit_statuses == [0, 0, 0]
 
     def test_dodgy_cmd(self):
-        e = ArrayExecutor(['ls', 'non_existent_cmd', 'pwd'], stream=True)
+        e = self.executor_cls(['ls', 'non_existent_cmd', 'pwd'], stream=True)
         for s in e.executors:
             s.error = Mock()
 
         e.error = Mock()
         e.start()
-        with pytest.raises(EGCGError) as err:
-            e.join()
+        assert e.join() == 127
 
-        assert 'Commands failed' in str(err)
-        e.error.assert_called_with('EGCGError: self.proc command failed: non_existent_cmd')
+    def test_internal_error(self):
+        with patch.object(StreamExecutor, 'info', side_effect=ValueError('Something went wrong')):
+            with pytest.raises(EGCGError) as err:
+                self.execute('ls')
+
+            assert 'Commands failed' in str(err)
+
+    def test_process(self):
+        e = self.executor_cls(['ls ' + os.path.dirname(self.assets_path)], stream=True)
+        assert e.proc is None
+        proc = e._process()
+        assert proc is e.proc and isinstance(e.proc, subprocess.Popen)
+
+    def test_bash_syntax(self):
+        with patch.object(StreamExecutor, 'info') as mocked_info:
+            assert self.execute('ls -lh %s | grep __init__' % os.path.dirname(self.assets_path)) == 0
+
+        assert '__init__.py' in mocked_info.call_args_list[1][0][0]
 
 
 class TestClusterExecutor(TestEGCG):
@@ -102,7 +132,8 @@ class TestClusterExecutor(TestEGCG):
         with pytest.raises(EGCGError) as err, patch(get_stdout, return_value=None), patch(sleep):
             self.executor.cmds = [os.path.join(self.assets_path, 'non_existent_script.sh')]
             self.executor.start()
-            assert str(err) == 'Job submission failed'
+
+        assert str(err).endswith('Job submission failed')
 
     def test_join(self):
         job_finished = self.ppath + '._job_finished'

--- a/tests/test_executor/test_executors.py
+++ b/tests/test_executor/test_executors.py
@@ -17,18 +17,14 @@ class TestExecutor(TestEGCG):
 
     def execute(self, *args, **kwargs):
         e = self.executor_cls(*args, **kwargs)
-        try:
-            e.start()
-        except NotImplementedError:
-            pass
-
+        e.start()
         return e.join()
 
     def test_cmd(self):
         assert self.execute('ls ' + os.path.dirname(self.assets_path)) == 0
 
     def test_dodgy_cmd(self):
-        assert self.execute('dodgy_cmd') == 127
+        assert self.execute('dodgy_cmd') == 127  # command not found
 
     def test_script(self):
         assert self.execute(os.path.join(self.assets_path, 'countdown.sh')) == 0
@@ -81,6 +77,11 @@ class TestArrayExecutor(TestExecutor):
         e.error = Mock()
         e.start()
         assert e.join() == 127
+        assert e.exit_statuses == [
+            0,  # ls
+            127,  # command not found
+            0  # pwd
+        ]
 
     def test_internal_error(self):
         with patch.object(StreamExecutor, 'info', side_effect=ValueError('Something went wrong')):

--- a/tests/test_executor/test_script_writers.py
+++ b/tests/test_executor/test_script_writers.py
@@ -81,10 +81,6 @@ class TestScriptWriter(TestEGCG):
         self.script_writer.save()
         assert 'a_line\n' in open(self.script_writer.script_name, 'r').readlines()
 
-    def test_trim_field(self):
-        s = script_writers.PBSWriter('a_job_name_too_long_for_pbs', 'a_working_dir', 'a_job_queue')
-        assert s.cluster_config['job_name'] == 'a_job_name_too_'
-
     def test(self):
         self.script_writer.log_commands = False
         self.script_writer.register_cmds('some', 'preliminary', 'cmds', parallel=False)
@@ -111,6 +107,10 @@ class TestPBSWriter(TestScriptWriter):
         '',
         'cd ' + working_dir
     ]
+
+    def test_trim_field(self):
+        s = script_writers.PBSWriter('a_job_name_too_long_for_pbs', 'a_working_dir', 'a_job_queue', 1, 1)
+        assert s.cluster_config['job_name'] == 'a_job_name_too_'
 
 
 class TestSlurmWriter(TestScriptWriter):

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -1,9 +1,7 @@
 import sqlite3
 from unittest.mock import patch
-from tests import TestEGCG, FakeRestResponse
+from tests import FakeRestResponse
 from egcg_core import ncbi
-from egcg_core.config import cfg
-cfg.load_config_file(TestEGCG.etc_config)
 
 
 fetch_from_eutils = ncbi._fetch_from_eutils

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -6,7 +6,6 @@ from smtplib import SMTPException
 from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
-from egcg_core.config import cfg
 from egcg_core import notifications as n
 from egcg_core.exceptions import EGCGError
 from tests import TestEGCG
@@ -31,7 +30,6 @@ class FakeSMTP(Mock):
 
 class TestNotificationCentre(TestEGCG):
     def setUp(self):
-        cfg.load_config_file(TestEGCG.etc_config)
         self.notification_centre = n.NotificationCentre('a_name')
 
     def test_config_init(self):


### PR DESCRIPTION
Refactoring Executor tests. Also:

- Using `shell=True` in local execution - closes #85 
- Using context manager in config loading - closes #89
- Adding a multiprocessing Lock to WrappedFunc - closes #93
- Catching `Exception` in `Communicator.__del__` - closes #94
- Freezing dependencies - closes #95
- Allowing executor to submit to alternate job queues - closes #97

🔨 💥 💥 💥 💥 💥 💥 