### PR TITLE
Dependency fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest_xdist==1.24.1
 pytest_cov==2.6.1
 requests==2.20.0
 PyYAML==5.1b3
-pyclarity_lims==0.4.5
-jinja2==2.8
+pyclarity_lims==0.4.8
+jinja2==2.10.1
 asana==0.6.7
 cached_property==1.5.1


### PR DESCRIPTION
- Updates Jinja2 to 2.20.1 - fixes [GitHub security alert](https://nvd.nist.gov/vuln/detail/CVE-2019-10906)
- Updates pyclarity_lims to 0.4.8 - required for clarity_scripts build, e.g. https://travis-ci.org/EdinburghGenomics/clarity_scripts/jobs/564009262