### PR TITLE
Load data in integration tests

### DIFF
--- a/egcg_core/integration_testing.py
+++ b/egcg_core/integration_testing.py
@@ -94,6 +94,9 @@ class ReportingAppIntegrationTest(IntegrationTest):
     container_id = None
     container_ip = None
     container_port = None
+    lims_data_yaml = None
+    users_sqlite = None
+    mongo_db = None
 
     @property
     def reporting_app_data(self):
@@ -106,13 +109,13 @@ class ReportingAppIntegrationTest(IntegrationTest):
     def _loadup_directory_with_data(self):
         """Prepare the directory that will be passed on to reporting app docker image."""
         os.makedirs(self.reporting_app_data, exist_ok=True)
-        lims_data_yaml = self.cfg.query('reporting_app', 'lims_data_yaml')
+        lims_data_yaml = self.cfg.query('reporting_app', 'lims_data_yaml', ret_default=self.lims_data_yaml)
         if lims_data_yaml and os.path.isfile(lims_data_yaml):
             shutil.copyfile(lims_data_yaml, os.path.join(self.reporting_app_data, 'data_for_clarity_lims.yaml'))
-        users_sqlite = self.cfg.query('reporting_app', 'users_sqlite')
+        users_sqlite = self.cfg.query('reporting_app', 'users_sqlite', ret_default=self.users_sqlite)
         if users_sqlite and os.path.isfile(users_sqlite):
             shutil.copyfile(users_sqlite, os.path.join(self.reporting_app_data, 'users.sqlite'))
-        mongo_db = self.cfg.query('reporting_app', 'mongo_db')
+        mongo_db = self.cfg.query('reporting_app', 'mongo_db', ret_default=self.mongo_db)
         if mongo_db and os.path.isdir(mongo_db):
             shutil.copytree(mongo_db, os.path.join(self.reporting_app_data, 'db'))
 

--- a/egcg_core/integration_testing.py
+++ b/egcg_core/integration_testing.py
@@ -114,7 +114,7 @@ class ReportingAppIntegrationTest(IntegrationTest):
             shutil.copyfile(users_sqlite, os.path.join(self.reporting_app_data, 'users.sqlite'))
         mongo_db = self.cfg.query('reporting_app', 'mongo_db')
         if mongo_db and os.path.isdir(mongo_db):
-            shutil.copytree(users_sqlite, os.path.join(self.reporting_app_data, 'db'))
+            shutil.copytree(mongo_db, os.path.join(self.reporting_app_data, 'db'))
 
     def setUp(self):
         super().setUp()

--- a/tests/test_integration_testing.py
+++ b/tests/test_integration_testing.py
@@ -83,7 +83,7 @@ class TestIntegrationTesting(TestEGCG):
         assert os.listdir(reporting_app_data_dir) == ['data_for_clarity_lims.yaml', 'db', 'users.sqlite']
         assert filecmp.cmp(os.path.join(reporting_app_data_dir, 'data_for_clarity_lims.yaml'), self.etc_config)
         assert filecmp.cmp(os.path.join(reporting_app_data_dir, 'users.sqlite'), self.etc_config)
-        assert os.listdir(os.path.join(reporting_app_data_dir, 'db')) == os.listdir(self.etc)
+        assert sorted(os.listdir(os.path.join(reporting_app_data_dir, 'db'))) == sorted(os.listdir(self.etc))
         # Check that the command were call properly
         assert mocked_check_output.call_count == 2
         mocked_check_output.assert_any_call(

--- a/tests/test_integration_testing.py
+++ b/tests/test_integration_testing.py
@@ -1,11 +1,12 @@
+import filecmp
 import os
 import requests
-from unittest import TestCase
 from unittest.mock import Mock, patch
 from egcg_core import integration_testing, config
+from tests import TestEGCG
 
 
-class TestIntegrationTesting(TestCase):
+class TestIntegrationTesting(TestEGCG):
     def setUp(self):
         self.original_baseurl = integration_testing.rest_communication.default.baseurl
 
@@ -15,7 +16,6 @@ class TestIntegrationTesting(TestCase):
     def test_wrapped_func(self):
         if os.path.isfile('checks.log'):
             os.remove('checks.log')
-
         w = integration_testing.WrappedFunc(self, self.assertEqual)
         w('a check', 1, 1)
         with self.assertRaises(AssertionError):
@@ -43,6 +43,10 @@ class TestIntegrationTesting(TestCase):
     @patch('egcg_core.integration_testing.get_cfg')
     @patch('egcg_core.integration_testing.check_output')
     def test_reporting_app_integration_test(self, mocked_check_output, mocked_get_cfg, mocked_sleep, mocked_get):
+        # Change directory to local test folder
+        test_dir = os.path.abspath(os.path.dirname(__file__))
+        os.chdir(test_dir)
+        reporting_app_data_dir = os.path.join(test_dir, 'reporting_app_data')
         mocked_check_output.side_effect = [
             b'docker_id\n',
             (
@@ -58,12 +62,23 @@ class TestIntegrationTesting(TestCase):
         ]
         fake_cfg = config.Configuration()
         fake_cfg.content = {
-            'reporting_app': {'image_name': 'an_image', 'username': 'a_user', 'password': 'a_password'}
+            'reporting_app': {'image_name': 'an_image', 'username': 'a_user', 'password': 'a_password',
+                              'lims_data_yaml': self.etc_config}
         }
         mocked_get_cfg.return_value = fake_cfg
-
         t = integration_testing.ReportingAppIntegrationTest()
         t.setUp()
+
+        # Check that the config file has been copied
+        assert os.listdir(reporting_app_data_dir) == ['data_for_clarity_lims.yaml']
+        assert filecmp.cmp(os.path.join(reporting_app_data_dir, 'data_for_clarity_lims.yaml'), self.etc_config)
+        # Check that the command were call properly
+        assert mocked_check_output.call_count == 2
+        mocked_check_output.assert_any_call(
+            ['docker', 'run', '-d', '-v', '%s:/opt/etc' % reporting_app_data_dir, 'an_image', 'master']
+        )
+        mocked_check_output.assert_any_call(['docker', 'inspect', 'docker_id'])
+        # Check that the retrieval of the IP works
         mocked_get.assert_called_with('http://1.2.3.4:80/api/0.1', timeout=2)
         assert mocked_get.call_count == 2
         assert mocked_sleep.call_count == 1

--- a/tests/test_integration_testing.py
+++ b/tests/test_integration_testing.py
@@ -80,7 +80,7 @@ class TestIntegrationTesting(TestEGCG):
         t.setUp()
 
         # Check that the config file has been copied
-        assert os.listdir(reporting_app_data_dir) == ['data_for_clarity_lims.yaml', 'db', 'users.sqlite']
+        assert sorted(os.listdir(reporting_app_data_dir)) == sorted(['data_for_clarity_lims.yaml', 'db', 'users.sqlite'])
         assert filecmp.cmp(os.path.join(reporting_app_data_dir, 'data_for_clarity_lims.yaml'), self.etc_config)
         assert filecmp.cmp(os.path.join(reporting_app_data_dir, 'users.sqlite'), self.etc_config)
         assert sorted(os.listdir(os.path.join(reporting_app_data_dir, 'db'))) == sorted(os.listdir(self.etc))


### PR DESCRIPTION
This is a PR on the back of https://github.com/EdinburghGenomics/Reporting-App/pull/248 to address EdinburghGenomics/Analysis-Driver#394. 
It adds three new options to the integration tests so we can load push data to the reporting app.