### PR TITLE
Species is now returned from the reporting app API

### DIFF
--- a/egcg_core/clarity.py
+++ b/egcg_core/clarity.py
@@ -1,5 +1,6 @@
 import re
 from pyclarity_lims.lims import Lims
+from egcg_core import rest_communication
 from egcg_core.config import cfg
 from egcg_core.app_logging import logging_default as log_cfg
 from egcg_core.exceptions import EGCGError
@@ -107,7 +108,7 @@ def get_genome_version(sample_id, species=None):
         return None
     genome_version = s.udf.get('Genome Version', None)
     if not genome_version and species:
-        return cfg.query('species', species, 'default')
+        return rest_communication.get_document('species', where={'name': species})['default_version']
     return genome_version
 
 


### PR DESCRIPTION
It no longer uses the cfg. The change involves using the built in rest_communicator to retrieve the matching species information. 

closes #102 